### PR TITLE
Add reproducible Windows deployment scripts and migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.py[cod]
 rai/server_db/*.sqlite
+logs/
+server/*.sqlite*

--- a/rai/server/db_utils.py
+++ b/rai/server/db_utils.py
@@ -1,50 +1,76 @@
-"""Shared SQLite helpers for the server components."""  # FIX: provide reusable database utilities
-from __future__ import annotations  # FIX: ensure future annotations support
+"""Shared SQLite helpers for the server components."""
+from __future__ import annotations
 
-import sqlite3  # FIX: interact with SQLite database
-from pathlib import Path  # FIX: handle filesystem paths
-from typing import Dict, List  # FIX: provide precise typing aliases
+import sqlite3
+from pathlib import Path
+from typing import Dict, List
 
-DB_PATH = Path(__file__).resolve().parents[1] / "server" / "apps.sqlite"  # FIX: canonical database path
+from server.init_db import DEFAULT_DB_PATH as DEFAULT_SERVER_DB_PATH, apply_migrations, get_logger
+
+DB_PATH = Path(DEFAULT_SERVER_DB_PATH)
+_LOGGER = get_logger()
 
 
-def ensure_schema(path: Path = DB_PATH) -> None:  # FIX: create schema if missing
-    path.parent.mkdir(parents=True, exist_ok=True)  # FIX: ensure directory exists
-    with sqlite3.connect(path) as conn:  # FIX: open database connection
-        conn.execute(  # FIX: create apps table with expected columns
+def ensure_schema(path: Path = DB_PATH) -> None:
+    """Ensure the SQLite schema is present by applying migrations."""
+
+    target = Path(path) if path else DB_PATH
+    apply_migrations(db_path=target, logger=_LOGGER)
+
+
+def load_apps(path: Path = DB_PATH) -> List[Dict[str, object]]:
+    """Return the list of active installs for the parser catalogue."""
+
+    ensure_schema(path)
+    with sqlite3.connect(path) as conn:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS apps (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                display_name TEXT NOT NULL,
-                type TEXT NOT NULL,
-                exe_path TEXT,
-                process_name TEXT,
-                app_id TEXT,
-                source TEXT DEFAULT 'scan',
-                last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                UNIQUE(name, type)
+            SELECT
+                lower(a.display_name) AS normalized_name,
+                a.display_name,
+                CASE WHEN i.package_id IS NOT NULL THEN 'UWP' ELSE 'EXE' END AS app_type,
+                b.exe_path,
+                NULL AS process_name,
+                p.package_fullname AS app_id,
+                i.source,
+                i.last_seen_at,
+                h.hostname
+            FROM installs i
+            JOIN hosts h ON h.id = i.host_id
+            JOIN apps_catalog a ON a.id = i.app_catalog_id
+            LEFT JOIN packages p ON p.id = i.package_id
+            LEFT JOIN binaries b ON b.id = i.binary_id
+            WHERE i.is_active = 1 AND i.removed_at IS NULL
+            ORDER BY i.last_seen_at DESC
+            """
+        )
+        apps: List[Dict[str, object]] = []
+        for row in cursor.fetchall():
+            apps.append(
+                {
+                    "name": row["normalized_name"],
+                    "display_name": row["display_name"],
+                    "type": row["app_type"],
+                    "exe_path": row["exe_path"],
+                    "process_name": row["process_name"],
+                    "app_id": row["app_id"],
+                    "source": row["source"],
+                    "last_seen": row["last_seen_at"],
+                    "hostname": row["hostname"],
+                }
             )
-            """
-        )
-        conn.execute(  # FIX: add unique index for faster lookups
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_apps_name_type ON apps(name, type)"
-        )
-        conn.commit()  # FIX: persist schema changes
+        return apps
 
 
-def load_apps(path: Path = DB_PATH) -> List[Dict[str, object]]:  # FIX: fetch catalogue entries
-    ensure_schema(path)  # FIX: guard against missing schema
-    with sqlite3.connect(path) as conn:  # FIX: open database connection for reads
-        conn.row_factory = sqlite3.Row  # FIX: map rows to dict-like objects
-        cursor = conn.execute(  # FIX: retrieve all apps ordered by last seen
-            "SELECT name, display_name, type, exe_path, process_name, app_id, source, last_seen FROM apps ORDER BY last_seen DESC"
-        )
-        return [dict(row) for row in cursor.fetchall()]  # FIX: convert rows to dictionaries
+def scan_and_update_db(path: Path = DB_PATH) -> None:
+    """Run the client scanner and persist results into the shared database."""
 
+    ensure_schema(path)
+    from ..client import scanner  # Lazy import to avoid Windows-only deps at import time
 
-def scan_and_update_db(path: Path = DB_PATH) -> None:  # FIX: delegate scanning to client scanner when available
-    from ..client import scanner  # FIX: local import to avoid hard dependency at module load
+    if hasattr(scanner, "scan_and_update_db"):
+        scanner.scan_and_update_db(path)
+    else:  # pragma: no cover - compatibility shim until scanner grows DB integration
+        _LOGGER.warning("Scanner module does not expose scan_and_update_db")
 
-    scanner.ensure_schema(path)  # FIX: reuse client schema logic for compatibility
-    scanner.scan_and_update_db(path)  # FIX: trigger scanner update against shared DB

--- a/rai/server/init_db.py
+++ b/rai/server/init_db.py
@@ -1,20 +1,18 @@
-"""Initialise the SQLite database and optionally trigger a scan."""
+"""Compatibility wrapper around the deployment migration runner."""
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
-from .db_utils import DB_PATH, ensure_schema, scan_and_update_db  # FIX: use shared server utilities
-
-logging.basicConfig(level=logging.INFO)
+from .db_utils import DB_PATH, ensure_schema, scan_and_update_db
 
 
 def init(db_path: Path | None = None, run_scan: bool = True) -> None:
-    path = db_path or DB_PATH  # FIX: resolve database path using shared constant
-    logging.info("Inicializando base de datos en %s", path)
-    ensure_schema(path)  # FIX: prepare schema via shared helper
+    """Initialise the database and optionally trigger a scan."""
+
+    target = db_path or DB_PATH
+    ensure_schema(target)
     if run_scan:
-        scan_and_update_db(path)  # FIX: trigger scanner via shared wrapper
+        scan_and_update_db(target)
 
 
 if __name__ == "__main__":

--- a/scripts/deploy_db.bat
+++ b/scripts/deploy_db.bat
@@ -1,0 +1,26 @@
+@echo off
+REM =====================================================================
+REM RAI-MINI :: Database deployment helper
+REM Prerequisites: Python 3.10+ available in PATH, write permissions.
+REM Optional: Run from an elevated prompt when deploying system-wide.
+REM =====================================================================
+setlocal
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%.."
+
+if not exist "server" mkdir "server"
+if not exist "logs" mkdir "logs"
+
+echo [deploy_db] Applying database migrations...
+python server\init_db.py
+set "ERR=%ERRORLEVEL%"
+if not "%ERR%"=="0" (
+    echo [deploy_db] Migration failed with code %ERR%.
+    popd
+    endlocal
+    exit /b %ERR%
+)
+
+echo [deploy_db] Database ready at %CD%\server\apps.sqlite
+popd
+endlocal

--- a/scripts/install_service.bat
+++ b/scripts/install_service.bat
@@ -1,0 +1,68 @@
+@echo off
+REM =====================================================================
+REM RAI-MINI :: Install the Windows service for the server API
+REM Prerequisites: Administrator Command Prompt, Python 3.10+, NSSM installed.
+REM   Define NSSM_PATH in .env (e.g. NSSM_PATH=C:\Tools\nssm.exe).
+REM Optional: Define PYTHON_PATH in .env to override the python executable.
+REM =====================================================================
+setlocal enabledelayedexpansion
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%.."
+
+call :load_env
+
+if not defined NSSM_PATH (
+    echo [install_service] NSSM_PATH not set. Edit .env and add NSSM_PATH=C:\path\to\nssm.exe
+    popd
+    endlocal
+    exit /b 1
+)
+
+if not exist "%NSSM_PATH%" (
+    echo [install_service] NSSM executable not found at "%NSSM_PATH%".
+    popd
+    endlocal
+    exit /b 1
+)
+
+set "PYTHON_CMD=%PYTHON_PATH%"
+if not defined PYTHON_CMD set "PYTHON_CMD=python"
+
+set "SERVICE_NAME=RAI-Server"
+set "APP_ROOT=%CD%"
+set "SERVICE_ARGS=-m rai.server.app"
+
+if not exist "%APP_ROOT%\logs" mkdir "%APP_ROOT%\logs"
+
+"%NSSM_PATH%" install %SERVICE_NAME% "%PYTHON_CMD%" %SERVICE_ARGS%
+if errorlevel 1 goto :error
+
+"%NSSM_PATH%" set %SERVICE_NAME% AppDirectory "%APP_ROOT%"
+"%NSSM_PATH%" set %SERVICE_NAME% Start SERVICE_AUTO_START
+"%NSSM_PATH%" set %SERVICE_NAME% AppStdout "%APP_ROOT%\logs\server-service.log"
+"%NSSM_PATH%" set %SERVICE_NAME% AppStderr "%APP_ROOT%\logs\server-service.log"
+
+echo [install_service] Service %SERVICE_NAME% installed successfully.
+popd
+endlocal
+exit /b 0
+
+:load_env
+set "ENV_FILE=%CD%\.env"
+if exist "%ENV_FILE%" (
+    for /f "usebackq tokens=1,* delims==" %%A in (`findstr /R "^NSSM_PATH=" "%ENV_FILE%"`) do (
+        set "NSSM_PATH=%%~B"
+    )
+    for /f "usebackq tokens=1,* delims==" %%A in (`findstr /R "^PYTHON_PATH=" "%ENV_FILE%"`) do (
+        set "PYTHON_PATH=%%~B"
+    )
+)
+if defined NSSM_PATH set "NSSM_PATH=!NSSM_PATH:\"=!"
+if defined PYTHON_PATH set "PYTHON_PATH=!PYTHON_PATH:\"=!"
+exit /b 0
+
+:error
+echo [install_service] Failed to install service (errorlevel %ERRORLEVEL%).
+popd
+endlocal
+exit /b %ERRORLEVEL%

--- a/scripts/start_service.bat
+++ b/scripts/start_service.bat
@@ -1,0 +1,11 @@
+@echo off
+REM =====================================================================
+REM RAI-MINI :: Start the Windows service for the server API
+REM Prerequisites: Administrator Command Prompt.
+REM =====================================================================
+setlocal
+set "SERVICE_NAME=RAI-Server"
+
+echo [start_service] Starting %SERVICE_NAME%...
+sc start "%SERVICE_NAME%"
+endlocal

--- a/scripts/stop_service.bat
+++ b/scripts/stop_service.bat
@@ -1,0 +1,11 @@
+@echo off
+REM =====================================================================
+REM RAI-MINI :: Stop the Windows service for the server API
+REM Prerequisites: Administrator Command Prompt.
+REM =====================================================================
+setlocal
+set "SERVICE_NAME=RAI-Server"
+
+echo [stop_service] Stopping %SERVICE_NAME%...
+sc stop "%SERVICE_NAME%"
+endlocal

--- a/scripts/uninstall_service.bat
+++ b/scripts/uninstall_service.bat
@@ -1,0 +1,35 @@
+@echo off
+REM =====================================================================
+REM RAI-MINI :: Uninstall the Windows service for the server API
+REM Prerequisites: Administrator Command Prompt. NSSM optional (used if available).
+REM =====================================================================
+setlocal enabledelayedexpansion
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%.."
+
+call :load_env
+set "SERVICE_NAME=RAI-Server"
+
+echo [uninstall_service] Stopping %SERVICE_NAME% if running...
+sc stop "%SERVICE_NAME%" >nul 2>&1
+
+if defined NSSM_PATH if exist "%NSSM_PATH%" (
+    "%NSSM_PATH%" remove %SERVICE_NAME% confirm
+) else (
+    sc delete "%SERVICE_NAME%" >nul 2>&1
+)
+
+echo [uninstall_service] Service removal requested.
+popd
+endlocal
+exit /b 0
+
+:load_env
+set "ENV_FILE=%CD%\.env"
+if exist "%ENV_FILE%" (
+    for /f "usebackq tokens=1,* delims==" %%A in (`findstr /R "^NSSM_PATH=" "%ENV_FILE%"`) do (
+        set "NSSM_PATH=%%~B"
+    )
+)
+if defined NSSM_PATH set "NSSM_PATH=!NSSM_PATH:\"=!"
+exit /b 0

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for deployment helpers."""

--- a/server/init_db.py
+++ b/server/init_db.py
@@ -1,0 +1,218 @@
+"""SQLite migration runner used for Windows deployments."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+LOG_FILE = LOG_DIR / "server.log"
+DEFAULT_DB_PATH = Path(__file__).resolve().parent / "apps.sqlite"
+DEFAULT_MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
+MIGRATION_TABLE = "_schema_migrations"
+
+
+def get_logger() -> logging.Logger:
+    """Return a configured logger that writes to the server log."""
+
+    logger = logging.getLogger("server.init_db")
+    if logger.handlers:
+        return logger
+
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s :: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    file_handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    logger.propagate = False
+    return logger
+
+
+@dataclass(frozen=True)
+class Migration:
+    """Represents a SQL migration file on disk."""
+
+    path: Path
+
+    @property
+    def identifier(self) -> str:
+        return self.path.name
+
+    def read(self) -> str:
+        return self.path.read_text(encoding="utf-8")
+
+
+class DatabaseMigrator:
+    """Apply SQL migrations sequentially keeping track of state."""
+
+    def __init__(
+        self,
+        db_path: Path,
+        migrations_dir: Path,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.db_path = db_path
+        self.migrations_dir = migrations_dir
+        self.logger = logger or get_logger()
+
+    def migrate(self) -> List[str]:
+        """Apply pending migrations and return the identifiers executed."""
+
+        if not self.migrations_dir.exists():
+            raise FileNotFoundError(f"Migrations directory not found: {self.migrations_dir}")
+
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        applied: List[str] = []
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("PRAGMA foreign_keys = ON;")
+            self._ensure_migrations_table(conn)
+            already_applied = set(self._get_applied_migrations(conn))
+
+            for migration in self._discover_migrations():
+                if migration.identifier in already_applied:
+                    self.logger.info("Migration %s already applied", migration.identifier)
+                    continue
+
+                self.logger.info("Applying migration %s", migration.identifier)
+                conn.executescript(migration.read())
+                conn.execute(
+                    f"INSERT INTO {MIGRATION_TABLE} (id) VALUES (?)",
+                    (migration.identifier,),
+                )
+                conn.commit()
+                applied.append(migration.identifier)
+
+        if applied:
+            self.logger.info("Applied %d migration(s)", len(applied))
+        else:
+            self.logger.info("Database already up to date")
+        return applied
+
+    def _discover_migrations(self) -> Sequence[Migration]:
+        files = sorted(self.migrations_dir.glob("*.sql"))
+        return [Migration(path=file) for file in files]
+
+    def _ensure_migrations_table(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {MIGRATION_TABLE} (
+                id TEXT PRIMARY KEY,
+                applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+    def _get_applied_migrations(self, conn: sqlite3.Connection) -> Iterable[str]:
+        cursor = conn.execute(f"SELECT id FROM {MIGRATION_TABLE} ORDER BY id")
+        return [row[0] for row in cursor.fetchall()]
+
+
+def apply_migrations(
+    db_path: Path | None = None,
+    migrations_dir: Path | None = None,
+    logger: logging.Logger | None = None,
+) -> List[str]:
+    """Helper to run migrations programmatically."""
+
+    resolved_db = Path(db_path or DEFAULT_DB_PATH)
+    resolved_migrations = Path(migrations_dir or DEFAULT_MIGRATIONS_DIR)
+    migrator = DatabaseMigrator(resolved_db, resolved_migrations, logger=logger)
+    return migrator.migrate()
+
+
+def _prompt_reset_confirmation(db_path: Path, logger: logging.Logger) -> bool:
+    logger.warning("Reset requested for database %s", db_path)
+    first = input("This will permanently delete the database. Type 'yes' to continue: ")
+    if first.strip().lower() != "yes":
+        logger.info("Reset aborted at first confirmation")
+        return False
+
+    second = input(f"Type the database filename ({db_path.name}) to confirm: ")
+    if second.strip() != db_path.name:
+        logger.info("Reset aborted: filename did not match")
+        return False
+    return True
+
+
+def reset_database(db_path: Path, logger: logging.Logger) -> None:
+    """Remove the SQLite database and its SQLite sidecar files."""
+
+    if not db_path.exists():
+        logger.info("Database %s not found; nothing to reset", db_path)
+        return
+
+    logger.info("Removing database %s", db_path)
+    db_path.unlink()
+
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(str(db_path) + suffix)
+        if sidecar.exists():
+            logger.debug("Removing sidecar %s", sidecar)
+            sidecar.unlink()
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply SQLite migrations for RAI-MINI server")
+    parser.add_argument(
+        "--database",
+        dest="database",
+        type=Path,
+        default=DEFAULT_DB_PATH,
+        help="Path to the SQLite database file",
+    )
+    parser.add_argument(
+        "--migrations",
+        dest="migrations",
+        type=Path,
+        default=DEFAULT_MIGRATIONS_DIR,
+        help="Directory containing .sql migrations",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Delete the database before applying migrations (requires double confirmation)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    logger = get_logger()
+
+    try:
+        db_path = args.database.resolve()
+        migrations_dir = args.migrations.resolve()
+
+        if args.reset:
+            if _prompt_reset_confirmation(db_path, logger):
+                reset_database(db_path, logger)
+            else:
+                logger.warning("Reset cancelled by user")
+                return 1
+
+        apply_migrations(db_path=db_path, migrations_dir=migrations_dir, logger=logger)
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive for CLI usage
+        logger.exception("Migration failed: %s", exc)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/migrations/001_init.sql
+++ b/server/migrations/001_init.sql
@@ -1,0 +1,113 @@
+-- Hosts discovered via scans; unique by hostname.
+CREATE TABLE hosts (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    hostname        TEXT NOT NULL UNIQUE,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Catalog of logical applications, normalized by name/publisher.
+CREATE TABLE apps_catalog (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    display_name        TEXT NOT NULL,
+    normalized_name     TEXT NOT NULL,
+    publisher           TEXT NOT NULL DEFAULT '',
+    name_hash           TEXT GENERATED ALWAYS AS (
+        normalized_name || '::' || publisher
+    ) VIRTUAL,
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (normalized_name, publisher)
+);
+
+-- UWP package metadata deduplicated globally.
+CREATE TABLE packages (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    package_fullname        TEXT NOT NULL UNIQUE,
+    package_name            TEXT NOT NULL,
+    publisher               TEXT,
+    version                 TEXT,
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Executable or shortcut binary metadata.
+CREATE TABLE binaries (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    exe_path        TEXT NOT NULL UNIQUE,
+    target_path     TEXT,
+    icon_path       TEXT,
+    file_hash       TEXT,
+    version         TEXT,
+    publisher       TEXT,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Logical installations (current + historical) per host/app/package/binary.
+CREATE TABLE installs (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    host_id             INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    app_catalog_id      INTEGER NOT NULL REFERENCES apps_catalog(id) ON DELETE CASCADE,
+    package_id          INTEGER REFERENCES packages(id) ON DELETE SET NULL,
+    binary_id           INTEGER REFERENCES binaries(id) ON DELETE SET NULL,
+    source              TEXT NOT NULL CHECK (source IN ('uwp', 'exe', 'shortcut')),
+    first_seen_at       DATETIME NOT NULL,
+    last_seen_at        DATETIME NOT NULL,
+    removed_at          DATETIME,
+    is_active           INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0,1)),
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (package_id IS NOT NULL AND binary_id IS NULL) OR
+        (package_id IS NULL AND binary_id IS NOT NULL)
+    )
+);
+
+-- Scan sessions per host.
+CREATE TABLE scans (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    host_id         INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    started_at      DATETIME NOT NULL,
+    completed_at    DATETIME,
+    total_items     INTEGER NOT NULL DEFAULT 0,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Raw items reported during a scan.
+CREATE TABLE scan_items (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_id                 INTEGER NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+    host_id                 INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    app_catalog_id          INTEGER NOT NULL REFERENCES apps_catalog(id) ON DELETE CASCADE,
+    package_id              INTEGER REFERENCES packages(id) ON DELETE SET NULL,
+    binary_id               INTEGER REFERENCES binaries(id) ON DELETE SET NULL,
+    source                  TEXT NOT NULL CHECK (source IN ('uwp', 'exe', 'shortcut')),
+    raw_name                TEXT NOT NULL,
+    raw_version             TEXT,
+    raw_publisher           TEXT,
+    exe_path                TEXT,
+    uwp_package_fullname    TEXT,
+    icon_path               TEXT,
+    file_hash               TEXT,
+    security_flag           INTEGER NOT NULL DEFAULT 0 CHECK (security_flag IN (0,1)),
+    security_reason         TEXT,
+    scanned_at              DATETIME NOT NULL,
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    item_key                TEXT GENERATED ALWAYS AS (COALESCE(exe_path, uwp_package_fullname)) STORED,
+    UNIQUE (scan_id, item_key)
+);
+
+-- Security findings tied to installs or specific scan items.
+CREATE TABLE security_findings (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    install_id          INTEGER REFERENCES installs(id) ON DELETE CASCADE,
+    scan_item_id        INTEGER REFERENCES scan_items(id) ON DELETE CASCADE,
+    flag_type           TEXT NOT NULL,
+    flag_value          TEXT,
+    reason              TEXT,
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (install_id IS NOT NULL) OR (scan_item_id IS NOT NULL)
+    )
+);

--- a/server/migrations/002_indexes.sql
+++ b/server/migrations/002_indexes.sql
@@ -1,0 +1,13 @@
+CREATE INDEX idx_hosts_hostname ON hosts(hostname);
+CREATE INDEX idx_apps_catalog_norm ON apps_catalog(normalized_name);
+CREATE INDEX idx_apps_catalog_publisher ON apps_catalog(publisher);
+CREATE UNIQUE INDEX idx_installs_host_package ON installs(host_id, package_id) WHERE package_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_installs_host_binary ON installs(host_id, binary_id) WHERE binary_id IS NOT NULL;
+CREATE INDEX idx_installs_active ON installs(host_id, is_active) WHERE is_active = 1;
+CREATE INDEX idx_binaries_publisher ON binaries(publisher);
+CREATE INDEX idx_binaries_hash ON binaries(file_hash);
+CREATE INDEX idx_packages_publisher ON packages(publisher);
+CREATE INDEX idx_scan_items_host ON scan_items(host_id);
+CREATE INDEX idx_scan_items_name ON scan_items(raw_name);
+CREATE INDEX idx_scan_items_publisher ON scan_items(raw_publisher);
+CREATE INDEX idx_security_findings_created ON security_findings(created_at);

--- a/server/migrations/003_views_triggers.sql
+++ b/server/migrations/003_views_triggers.sql
@@ -1,0 +1,169 @@
+-- View of current active installs with metadata.
+CREATE VIEW v_current_installs AS
+SELECT
+    i.id AS install_id,
+    h.hostname,
+    a.display_name,
+    a.publisher,
+    i.source,
+    i.first_seen_at,
+    i.last_seen_at,
+    p.package_fullname,
+    b.exe_path,
+    b.file_hash,
+    b.version AS binary_version,
+    p.version AS package_version
+FROM installs i
+JOIN hosts h ON h.id = i.host_id
+JOIN apps_catalog a ON a.id = i.app_catalog_id
+LEFT JOIN packages p ON p.id = i.package_id
+LEFT JOIN binaries b ON b.id = i.binary_id
+WHERE i.is_active = 1 AND i.removed_at IS NULL;
+
+-- View of security alerts linked to installs/items.
+CREATE VIEW v_security_alerts AS
+SELECT
+    sf.id AS finding_id,
+    sf.created_at,
+    sf.flag_type,
+    sf.flag_value,
+    sf.reason,
+    h.hostname,
+    a.display_name,
+    i.source,
+    si.scanned_at
+FROM security_findings sf
+LEFT JOIN installs i ON i.id = sf.install_id
+LEFT JOIN hosts h ON h.id = i.host_id
+LEFT JOIN apps_catalog a ON a.id = i.app_catalog_id
+LEFT JOIN scan_items si ON si.id = sf.scan_item_id;
+
+-- View with the latest scan per host.
+CREATE VIEW v_latest_scan_per_host AS
+SELECT s.*
+FROM scans s
+JOIN (
+    SELECT host_id, MAX(started_at) AS max_started
+    FROM scans
+    GROUP BY host_id
+) latest ON latest.host_id = s.host_id AND latest.max_started = s.started_at;
+
+-- Trigger to normalize display names and publisher on insert.
+CREATE TRIGGER trg_apps_catalog_normalize_ins
+AFTER INSERT ON apps_catalog
+FOR EACH ROW
+BEGIN
+    UPDATE apps_catalog
+    SET normalized_name = lower(trim(display_name)),
+        publisher = trim(publisher)
+    WHERE id = NEW.id;
+END;
+
+-- Trigger to enforce normalization on updates.
+CREATE TRIGGER trg_apps_catalog_normalize_check
+BEFORE UPDATE ON apps_catalog
+FOR EACH ROW
+BEGIN
+    SELECT CASE
+        WHEN lower(trim(NEW.display_name)) != NEW.normalized_name THEN
+            RAISE(ABORT, 'normalized_name must equal lower(trim(display_name))')
+    END;
+    SELECT CASE
+        WHEN trim(NEW.publisher) != NEW.publisher THEN
+            RAISE(ABORT, 'publisher must be trimmed')
+    END;
+END;
+
+-- Trigger to upsert installs when scan items arrive.
+CREATE TRIGGER trg_scan_items_after_insert
+AFTER INSERT ON scan_items
+FOR EACH ROW
+BEGIN
+    -- Update existing install for packages.
+    UPDATE installs
+    SET last_seen_at = NEW.scanned_at,
+        removed_at = NULL,
+        is_active = 1,
+        source = NEW.source,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE host_id = NEW.host_id
+      AND package_id = NEW.package_id
+      AND NEW.package_id IS NOT NULL;
+
+    -- Update existing install for binaries.
+    UPDATE installs
+    SET last_seen_at = NEW.scanned_at,
+        removed_at = NULL,
+        is_active = 1,
+        source = NEW.source,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE host_id = NEW.host_id
+      AND binary_id = NEW.binary_id
+      AND NEW.binary_id IS NOT NULL;
+
+    -- Insert new install if package not found.
+    INSERT INTO installs (host_id, app_catalog_id, package_id, binary_id, source,
+                          first_seen_at, last_seen_at, removed_at, is_active)
+    SELECT NEW.host_id, NEW.app_catalog_id, NEW.package_id, NULL, NEW.source,
+           NEW.scanned_at, NEW.scanned_at, NULL, 1
+    WHERE NEW.package_id IS NOT NULL
+      AND NOT EXISTS (
+            SELECT 1 FROM installs
+            WHERE host_id = NEW.host_id AND package_id = NEW.package_id
+        );
+
+    -- Insert new install if binary not found.
+    INSERT INTO installs (host_id, app_catalog_id, package_id, binary_id, source,
+                          first_seen_at, last_seen_at, removed_at, is_active)
+    SELECT NEW.host_id, NEW.app_catalog_id, NULL, NEW.binary_id, NEW.source,
+           NEW.scanned_at, NEW.scanned_at, NULL, 1
+    WHERE NEW.binary_id IS NOT NULL
+      AND NOT EXISTS (
+            SELECT 1 FROM installs
+            WHERE host_id = NEW.host_id AND binary_id = NEW.binary_id
+        );
+
+    UPDATE scans SET total_items = total_items + 1 WHERE id = NEW.scan_id;
+
+    -- Optional security heuristic for suspicious paths.
+    INSERT INTO security_findings (scan_item_id, flag_type, flag_value, reason)
+    SELECT NEW.id, 'path_watch', NEW.exe_path,
+           'Executable located in monitored directory'
+    WHERE NEW.security_flag = 0 AND NEW.exe_path IS NOT NULL AND (
+        lower(NEW.exe_path) LIKE '%\\temp\\%'
+        OR lower(NEW.exe_path) LIKE '%\\downloads\\%'
+    );
+END;
+
+-- Trigger to convert scanner security flag into findings.
+CREATE TRIGGER trg_scan_items_security_flag
+AFTER INSERT ON scan_items
+WHEN NEW.security_flag = 1
+BEGIN
+    INSERT INTO security_findings (scan_item_id, flag_type, flag_value, reason)
+    VALUES (NEW.id, 'scanner_flag', COALESCE(NEW.exe_path, NEW.uwp_package_fullname), NEW.security_reason);
+END;
+
+-- Trigger to close installs not reported when scan completes.
+CREATE TRIGGER trg_scans_complete_close_installs
+AFTER UPDATE OF completed_at ON scans
+FOR EACH ROW
+WHEN NEW.completed_at IS NOT NULL
+BEGIN
+    UPDATE installs
+    SET is_active = 0,
+        removed_at = NEW.completed_at,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE host_id = NEW.host_id
+      AND is_active = 1
+      AND last_seen_at < NEW.started_at
+      AND NOT EXISTS (
+            SELECT 1 FROM scan_items si
+            WHERE si.scan_id = NEW.id
+              AND si.host_id = NEW.host_id
+              AND (
+                    (si.package_id IS NOT NULL AND si.package_id = installs.package_id)
+                 OR (si.binary_id IS NOT NULL AND si.binary_id = installs.binary_id)
+              )
+        );
+END;


### PR DESCRIPTION
## Summary
- add structured SQLite migrations with a reusable migration runner
- update server helpers to apply migrations and surface the richer catalogue
- provide Windows deployment and service management batch scripts and ignore generated artifacts

## Testing
- python server/init_db.py
- python server/init_db.py --reset

------
https://chatgpt.com/codex/tasks/task_e_68de834043b883318f0662d150120c18